### PR TITLE
Fixes in RutInputFormatter and rutVerificationDigitRegex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 - Remove unused import of 'rut_input_formatter.dart' in main.dart
+- Update rutVerificationDigitRegex to allow for one or more digits before the verification digit in 'constants.dart'
+- Fix condition in RutInputFormatter to return oldValue when rutVerificationDigitRegex matches unformattedRut in 'rut_input_formatter.dart'
 
 # 0.2.0
 ### Added

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,1 +1,1 @@
-final RegExp rutVerificationDigitRegex = RegExp(r'^[0-9Kk]{1}$');
+final RegExp rutVerificationDigitRegex = RegExp(r'^\d+[0-9Kk]?$');

--- a/lib/src/rut_input_formatter.dart
+++ b/lib/src/rut_input_formatter.dart
@@ -8,7 +8,7 @@ class RutInputFormatter extends TextInputFormatter {
     String unformattedRut = removeRutFormatting(newValue.text);
     String formattedRut = formatRut(unformattedRut);
 
-    if (rutVerificationDigitRegex.hasMatch(unformattedRut)) return oldValue;
+    if (!rutVerificationDigitRegex.hasMatch(unformattedRut)) return oldValue;
 
     return TextEditingValue(
       text: formattedRut,


### PR DESCRIPTION
**Version:** 0.2.1

**Introduced Changes:**

**Fixed:** Adjusted the condition in RutInputFormatter to return oldValue when rutVerificationDigitRegex matches unformattedRut.
**Fixed:** Updated rutVerificationDigitRegex in constants.dart to allow for one or more digits before the verification digit.